### PR TITLE
Fix group page permalink

### DIFF
--- a/_pages/group.md
+++ b/_pages/group.md
@@ -3,7 +3,7 @@ title: "Denolle Quake Lab - People"
 layout: gridlay
 excerpt: "Denolle Quake Lab: People"
 sitemap: false
-permalink: /people/
+permalink: /group/
 ---
 
 # Group Members


### PR DESCRIPTION
## Summary
- Serve the group members page at `/group/` by correcting its permalink.

## Testing
- `bundle _2.7.1_ exec jekyll build`

------
https://chatgpt.com/codex/tasks/task_b_689837515ee4832ab7b15f35eb49ee0d