### PR TITLE
feat: modernize group page font

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -5,6 +5,7 @@
   <title>{% if page.title %}{{ page.title | escape }}{% else %}{{ site.title | escape }}{% endif %}</title>
   <meta name="description" content="{% if page.excerpt %}{{ page.excerpt | strip_html | strip_newlines | truncate: 160 }}{% else %}{{ site.description }}{% endif %}">
   <link rel="stylesheet" href="{{ "/css/main.css" | prepend: site.baseurl | prepend: site.url}}">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
   <link rel="canonical" href="{{ page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.url }}">
 <link rel="shortcut icon" type ="image/x-icon" href="/images/logopic/littlequake.png">
 

--- a/css/main.scss
+++ b/css/main.scss
@@ -10,7 +10,8 @@ img { margin-bottom: 24px;
 
 
 body {
-	padding-top: 70px;
+        padding-top: 70px;
+        font-family: 'Inter', sans-serif;
 }
 
 figcaption {


### PR DESCRIPTION
## Summary
- add Google Fonts link for Inter
- default to Inter sans-serif font site-wide

## Testing
- `bundle exec jekyll build` *(fails: bundler: command not found: jekyll)*

------
https://chatgpt.com/codex/tasks/task_b_6898378f26b4832a96dc9a411f5e7e20