### PR TITLE
Add GAIA HazLab surface events repository scaffold

### DIFF
--- a/gaia-hazlab-surface-events/.gitignore
+++ b/gaia-hazlab-surface-events/.gitignore
@@ -1,0 +1,11 @@
+__pycache__/
+*.py[cod]
+*.egg-info/
+.env
+.venv
+.ipynb_checkpoints
+.eggs/
+build/
+dist/
+.envrc
+.DS_Store

--- a/gaia-hazlab-surface-events/AGENTS.md
+++ b/gaia-hazlab-surface-events/AGENTS.md
@@ -1,0 +1,4 @@
+# Agent Notes
+
+- Maintain concise, self-contained documentation and configuration suitable for a new repository scaffold.
+- Prefer minimal, readable defaults for environment and packaging files.

--- a/gaia-hazlab-surface-events/LICENSE
+++ b/gaia-hazlab-surface-events/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 GAIA HazLab
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/gaia-hazlab-surface-events/README.md
+++ b/gaia-hazlab-surface-events/README.md
@@ -1,0 +1,26 @@
+# GAIA HazLab Surface Events
+
+This repository provides a scaffold for analyzing and documenting surface event data within the GAIA HazLab project. It includes a minimal Python package, reproducible environment configuration, and placeholders for notebooks and tests.
+
+## Project layout
+- `src/gaia_hazlab_surface/`: Python package for analysis utilities.
+- `notebooks/`: Interactive notebooks for exploratory analysis.
+- `tests/`: Basic testing harness for the package.
+
+## Getting started
+1. Create the conda environment:
+   ```bash
+   conda env create -f environment.yml
+   conda activate gaia-hazlab-surface-events
+   ```
+2. Install the package in editable mode:
+   ```bash
+   pip install -e .
+   ```
+3. Run the tests:
+   ```bash
+   pytest
+   ```
+
+## License
+See [LICENSE](LICENSE) for licensing details.

--- a/gaia-hazlab-surface-events/environment.yml
+++ b/gaia-hazlab-surface-events/environment.yml
@@ -1,0 +1,8 @@
+name: gaia-hazlab-surface-events
+channels:
+  - conda-forge
+dependencies:
+  - python=3.11
+  - pip
+  - pip:
+      - -e .

--- a/gaia-hazlab-surface-events/notebooks/README.md
+++ b/gaia-hazlab-surface-events/notebooks/README.md
@@ -1,0 +1,3 @@
+# Notebooks
+
+Place Jupyter notebooks for surface event analyses in this directory.

--- a/gaia-hazlab-surface-events/pyproject.toml
+++ b/gaia-hazlab-surface-events/pyproject.toml
@@ -1,0 +1,26 @@
+[build-system]
+requires = ["setuptools>=64", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "gaia-hazlab-surface-events"
+version = "0.0.1"
+description = "Scaffold for GAIA HazLab surface event analysis."
+authors = [{ name = "GAIA HazLab" }]
+license = { file = "LICENSE" }
+readme = "README.md"
+requires-python = ">=3.11"
+classifiers = [
+  "Programming Language :: Python :: 3",
+  "License :: OSI Approved :: MIT License",
+  "Operating System :: OS Independent",
+]
+dependencies = []
+
+[project.optional-dependencies]
+dev = [
+  "pytest>=7.0",
+]
+
+[tool.setuptools.packages.find]
+where = ["src"]

--- a/gaia-hazlab-surface-events/src/gaia_hazlab_surface/__init__.py
+++ b/gaia-hazlab-surface-events/src/gaia_hazlab_surface/__init__.py
@@ -1,0 +1,3 @@
+"""GAIA HazLab Surface Events package."""
+
+__all__ = []

--- a/gaia-hazlab-surface-events/tests/test_imports.py
+++ b/gaia-hazlab-surface-events/tests/test_imports.py
@@ -1,0 +1,4 @@
+def test_package_import():
+    import gaia_hazlab_surface
+
+    assert hasattr(gaia_hazlab_surface, "__all__")


### PR DESCRIPTION
## Summary
- add GAIA HazLab surface events repository skeleton with README and licensing
- provide environment and packaging configuration for the Python package
- include package, notebooks placeholder, and initial test harness

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_693d8575ba2c832aa1ea6c91e7d010c5)