### PR TITLE
Add pixi configuration and Dask app docs

### DIFF
--- a/gaia-hazlab-surface-events/README.md
+++ b/gaia-hazlab-surface-events/README.md
@@ -15,11 +15,27 @@ This repository provides a scaffold for analyzing and documenting surface event 
    ```
 2. Install the package in editable mode:
    ```bash
-   pip install -e .
+   python -m pip install -e .
    ```
 3. Run the tests:
    ```bash
    pytest
+   ```
+
+## Pixi setup
+Pixi provides a cross-platform environment and a `dask` app entrypoint.
+
+1. Install the environment:
+   ```bash
+   pixi install
+   ```
+2. Install the package in editable mode:
+   ```bash
+   pixi run python -m pip install -e .
+   ```
+3. Run the Dask app:
+   ```bash
+   pixi run dask --help
    ```
 
 ## License

--- a/gaia-hazlab-surface-events/pixi.toml
+++ b/gaia-hazlab-surface-events/pixi.toml
@@ -1,0 +1,20 @@
+[project]
+name = "gaia-hazlab-surface-events"
+version = "0.0.1"
+description = "Scaffold for GAIA HazLab surface event analysis."
+channels = ["conda-forge"]
+platforms = ["linux-64", "osx-64", "osx-arm64", "win-64"]
+
+[dependencies]
+python = "3.11.*"
+pip = "*"
+dask = "*"
+
+[feature.dev.dependencies]
+pytest = ">=7"
+
+[environments]
+default = { features = ["dev"] }
+
+[apps]
+dask = { cmd = "dask" }


### PR DESCRIPTION
### Motivation
- Provide a cross-platform, reproducible environment configuration using Pixi so contributors can install and run the project consistently.
- Expose a `dask` app entrypoint to simplify running Dask-related commands for distributed or parallel workflows.
- Avoid ambiguous installer invocation by using a canonical editable install command with `python -m pip`.

### Description
- Add `gaia-hazlab-surface-events/pixi.toml` that declares `python`, `pip`, and `dask` dependencies and defines an `apps.dask` entrypoint.
- Update `gaia-hazlab-surface-events/README.md` to replace `pip install -e .` with `python -m pip install -e .` and add a `Pixi setup` section.
- Document Pixi usage with the commands `pixi install`, `pixi run python -m pip install -e .`, and `pixi run dask --help`.

### Testing
- No automated tests were executed for this change because it only adds documentation and a Pixi configuration file.
- No unit tests or `pytest` runs were performed as part of this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69615c0748fc832a9bbe3172c3bf9e9d)